### PR TITLE
オブジェクトA＋オブジェクトB→オブジェクトC

### DIFF
--- a/src/components/DraggableBox.tsx
+++ b/src/components/DraggableBox.tsx
@@ -16,7 +16,8 @@ const DraggableBox: React.FC<Props> = (props) => {
       <DraggableBase {...props}>
         <mesh ref={props.refData.mesh}>
             <boxGeometry args={[1, 1, 1]} />
-            <meshStandardMaterial color="blue" />
+            {/* <meshStandardMaterial color="blue" /> */}
+            <meshStandardMaterial color="blue" transparent opacity={0.8} />
         </mesh>
       </DraggableBase>
     );


### PR DESCRIPTION
## 🖇 関連Issue
オブジェクトA＋オブジェクトB→オブジェクトC #13

<!-- GitHub Issueのリンクを記入してください -->
[https://github.com/babyhonpo/science-3d-labo/issues/13](url)

##  🎂 やったこと
- オブジェクトA＋オブジェクトB→オブジェクトC

<!-- 実装内容を書く -->
オブジェクトCにするには、オブジェクトAのオブジェクトBと定義しておいて、当たり判定があれば、オブジェクトCにするという処理をしています。

## ⛔ やってないこと
- オブジェクトA＋オブジェクトB→オブジェクトCが複数個できるロジックが作れていない。
- 例えば、オブジェクトC＋オブジェクトB→オブジェクトDになるなどの他のパターンの検証。

<!-- 今回スコープアウトしたこと -->
<!-- 不要ならセクションごと削除してください -->

## 💡 確認したこと

<!-- 実装者が自分で確認したこと -->

## 🏃‍♂️ その他

<!-- レビュワーに伝えたいことや感想など -->
